### PR TITLE
Specify an OTA platform to fix the build in the latest ESPHome

### DIFF
--- a/models/current/tubeszb-cc2652-poe-2023/firmware/esphome/tubeszb-cc2652-poe-2023.yaml
+++ b/models/current/tubeszb-cc2652-poe-2023/firmware/esphome/tubeszb-cc2652-poe-2023.yaml
@@ -46,6 +46,7 @@ api:
   reboot_timeout: 0s
 
 ota:
+  platform: esphome
 
 web_server:
   port: 80


### PR DESCRIPTION
This seems to have changed in 2024.6.0

I haven't audited other yamls as this is the only one my ESPHome currently builds.